### PR TITLE
Harden session edge cases

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -132,6 +132,9 @@ func RunStatus(args []string) error {
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
+	if flags.NArg() > 0 {
+		return fmt.Errorf("unknown argument: %s", flags.Arg(0))
+	}
 
 	store, err := coresession.DefaultStore()
 	if err != nil {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -129,3 +129,13 @@ func TestNewSessionRejectsInvalidInputs(t *testing.T) {
 		})
 	}
 }
+
+func TestRunStatusRejectsUnknownArgument(t *testing.T) {
+	err := RunStatus([]string{"unexpected"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "unknown argument: unexpected") {
+		t.Fatalf("error = %q, want unknown argument", err)
+	}
+}

--- a/internal/session/active.go
+++ b/internal/session/active.go
@@ -1,6 +1,9 @@
 package session
 
-import "errors"
+import (
+	"errors"
+	"time"
+)
 
 func ActiveState(store Store) (State, bool, error) {
 	state, ok, err := store.Read()
@@ -22,6 +25,12 @@ func ActiveState(store Store) (State, bool, error) {
 		return State{}, false, err
 	}
 	if !matches {
+		if err := store.Remove(); err != nil {
+			return State{}, false, err
+		}
+		return State{}, false, nil
+	}
+	if state.AutoStopAt != nil && !state.AutoStopAt.After(time.Now()) {
 		if err := store.Remove(); err != nil {
 			return State{}, false, err
 		}

--- a/internal/session/active_test.go
+++ b/internal/session/active_test.go
@@ -65,6 +65,14 @@ func TestActiveState(t *testing.T) {
 		assertStateRemovedAndFalse(t, store, storePath, unmatchingState)
 	})
 
+	t.Run("expired auto stop", func(t *testing.T) {
+		expiredAt := time.Now().Add(-time.Minute)
+		expiredState := validState
+		expiredState.Mode = ModeTimed
+		expiredState.AutoStopAt = &expiredAt
+		assertStateRemovedAndFalse(t, store, storePath, expiredState)
+	})
+
 	t.Run("invalid state", func(t *testing.T) {
 		invalidState := validState
 		invalidState.Mode = "invalid_mode"

--- a/internal/timer/timer.go
+++ b/internal/timer/timer.go
@@ -8,6 +8,8 @@ import (
 	"unicode"
 )
 
+const maxDuration = time.Duration(1<<63 - 1)
+
 func ParseDuration(value string) (time.Duration, error) {
 	value = strings.TrimSpace(value)
 	if value == "" {
@@ -29,7 +31,7 @@ func ParseDuration(value string) (time.Duration, error) {
 				return 0, fmt.Errorf("missing number before %q", r)
 			}
 
-			n, err := strconv.Atoi(number.String())
+			n, err := strconv.ParseInt(number.String(), 10, 64)
 			if err != nil {
 				return 0, fmt.Errorf("parse duration number: %w", err)
 			}
@@ -40,13 +42,19 @@ func ParseDuration(value string) (time.Duration, error) {
 				if seenHours || seenMinutes {
 					return 0, fmt.Errorf("hours must appear once before minutes")
 				}
-				total += time.Duration(n) * time.Hour
+				total, err = addDurationPart(total, n, time.Hour)
+				if err != nil {
+					return 0, err
+				}
 				seenHours = true
 			case 'm', 'M':
 				if seenMinutes {
 					return 0, fmt.Errorf("minutes must appear once")
 				}
-				total += time.Duration(n) * time.Minute
+				total, err = addDurationPart(total, n, time.Minute)
+				if err != nil {
+					return 0, err
+				}
 				seenMinutes = true
 			}
 			seenUnit = true
@@ -63,6 +71,19 @@ func ParseDuration(value string) (time.Duration, error) {
 	}
 
 	return total, nil
+}
+
+func addDurationPart(total time.Duration, n int64, unit time.Duration) (time.Duration, error) {
+	if n > int64(maxDuration/unit) {
+		return 0, fmt.Errorf("duration is too large")
+	}
+
+	part := time.Duration(n) * unit
+	if total > maxDuration-part {
+		return 0, fmt.Errorf("duration is too large")
+	}
+
+	return total + part, nil
 }
 
 func ParseUntil(now time.Time, value string) (time.Time, error) {

--- a/internal/timer/timer_test.go
+++ b/internal/timer/timer_test.go
@@ -23,6 +23,9 @@ func TestParseDuration(t *testing.T) {
 		{name: "minutes before hours", value: "30m1h", wantErr: true},
 		{name: "repeated hours", value: "1h2h", wantErr: true},
 		{name: "repeated minutes", value: "10m20m", wantErr: true},
+		{name: "overflow hours", value: "2562048h", wantErr: true},
+		{name: "overflow minutes", value: "153722868m", wantErr: true},
+		{name: "overflow total", value: "2562047h48m", wantErr: true},
 		{name: "invalid", value: "abc", wantErr: true},
 	}
 


### PR DESCRIPTION
## Summary
- reject duration values that overflow time.Duration
- clear expired active session state before reporting it as running
- reject unknown positional args for status

## Tests
- go test .\...